### PR TITLE
feat: add user profile API endpoint

### DIFF
--- a/sample-app/src/server.js
+++ b/sample-app/src/server.js
@@ -45,6 +45,27 @@ app.post('/api/data', (req, res) => {
   });
 });
 
+// New User Profile API endpoint
+// Returns user profile information based on user ID
+app.get('/api/users/:id', (req, res) => {
+  const userId = req.params.id;
+  
+  if (!userId || isNaN(userId)) {
+    return res.status(400).json({ 
+      error: 'Valid user ID is required',
+      received: userId 
+    });
+  }
+
+  res.json({
+    id: parseInt(userId),
+    name: `User ${userId}`,
+    email: `user${userId}@example.com`,
+    profileUrl: `/api/users/${userId}`,
+    createdAt: new Date().toISOString()
+  });
+});
+
 // Health check endpoint
 app.get('/health', (req, res) => {
   res.status(200).json({ status: 'OK' });


### PR DESCRIPTION
## Description
Added a new API endpoint `/api/users/:id` to retrieve user profile information.

## What Changed
- Added GET `/api/users/:id` endpoint
- Returns user profile with ID, name, email, and profile URL
- Includes input validation for user ID
- Error handling for invalid user IDs

## How to Test
1. Run the app: `npm start`
2. Test the endpoint:
   ```bash
   curl http://localhost:3000/api/users/123
   ```
3. Expected response:
   ```json
   {
     "id": 123,
     "name": "User 123",
     "email": "user123@example.com",
     "profileUrl": "/api/users/123",
     "createdAt": "2026-03-20T11:00:00.000Z"
   }
   ```

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update

## Testing
- [x] Tested locally with curl
- [x] Handles valid user IDs
- [x] Handles invalid user IDs with error response

## Related Issues
This is part of Task 10 - PR workflow demonstration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new API endpoint to retrieve user profile information by ID
  * User profiles include identification, name, email address, and account creation date
  * Invalid requests return descriptive error messages
  * Profile responses include a direct reference URL for convenient access

<!-- end of auto-generated comment: release notes by coderabbit.ai -->